### PR TITLE
Enabling bidder keys in targeting object of response for mobile apps

### DIFF
--- a/stored_requests/data/by_id/stored_requests/playwire.json
+++ b/stored_requests/data/by_id/stored_requests/playwire.json
@@ -5,7 +5,7 @@
         "prebid": {
             "targeting": {
                 "includewinners": true,
-                "includebidderkeys": false,
+                "includebidderkeys": true,
                 "mediatypepricegranularity": {
                     "banner": {
                         "ranges": [


### PR DESCRIPTION
This causes Prebid Server to include bidder-specific keys like `targeting.hb_pb_rubicon` in its response to auction requests where `"playwire"` is the stored request ID. See this [Prebid doc](https://docs.prebid.org/prebid-server/use-cases/pbs-sdk.html#the-sdk-gets-the-response) for more info.
