### PR TITLE
[CU-86b2yd01g] Configuring price granularity for mobile app requests to match GAM line items

### DIFF
--- a/stored_requests/data/by_id/stored_requests/playwire.json
+++ b/stored_requests/data/by_id/stored_requests/playwire.json
@@ -6,17 +6,26 @@
             "targeting": {
                 "includewinners": true,
                 "includebidderkeys": true,
-                "mediatypepricegranularity": {
-                    "banner": {
-                        "ranges": [
-                            {
-                                "max": 50,
-                                "min": 0,
-                                "increment": 0.01
-                            }
-                        ],
-                        "precision": 3
-                    }
+                "pricegranularity": {
+                    "ranges": [
+                        {
+                            "max": 3,
+                            "increment": 0.01
+                        },
+                        {
+                            "max": 8,
+                            "increment": 0.05
+                        },
+                        {
+                            "max": 15,
+                            "increment": 0.25
+                        },
+                        {
+                            "max": 30,
+                            "increment": 1
+                        }
+                    ],
+                    "precision": 2
                 }
             },
             "cache": {


### PR DESCRIPTION
https://app.clickup.com/t/86b2yd01g

Bid prices returned for app requests need to end up in the right buckets to match the line items in GAM. In addition, they need to use 2 decimals places, not 3.